### PR TITLE
Update Privacy Toolkit Links

### DIFF
--- a/_includes/toolset-body.html
+++ b/_includes/toolset-body.html
@@ -53,7 +53,7 @@
           
           <div class="b-tools__links">
             {% for link in pattern.links %}
-              <div class="b-tools__link"><a target="_blank" href="{{ site.baseurl | append: link.link }}">{{ link.title }}</a></div>
+              <div class="b-tools__link"><a target="_blank" href="{{ link.link }}">{{ link.title }}</a></div>
             {% endfor %}
           </div>
 

--- a/privacy_toolset.md
+++ b/privacy_toolset.md
@@ -36,7 +36,7 @@ patterns:
       - title: Cookies
         link: #
       - title: Consent
-        link: #
+        link: https://sagebionetworks.org/wp-content/uploads/2019/07/SageBio_EIC-Toolkit_V2_17July19_final.pdf
       - title: Study Details
         link: #
       - title: Data Sharing Options


### PR DESCRIPTION
 The "Consent" link on the homepage under "discovering and learning about the study" now points to Consent Tookit PDF