### PR TITLE
Allow URL to be specified for the Add a pattern button

### DIFF
--- a/_includes/toolkit-body.html
+++ b/_includes/toolkit-body.html
@@ -67,7 +67,7 @@
             {% endunless %}
           </div>
 
-        {% if pattern.add_a_pattern_link != nil %}
+        {% if pattern.add_a_pattern_link %}
           <a href="{{pattern.add_a_pattern_link}}" >
             <div class="b-tools__pattern-button scale-on-hover">
               <img src="{{ "/images/ic-add.svg" | relative_url }}">

--- a/_includes/toolkit-body.html
+++ b/_includes/toolkit-body.html
@@ -67,12 +67,15 @@
             {% endunless %}
           </div>
 
-
-          <div class="b-tools__pattern-button scale-on-hover">
-            <img src="{{ "/images/ic-add.svg" | relative_url }}">
-            <div>Add a pattern</div>
-          </div>
-        </div>
+        {% if pattern.add_a_pattern_link != nil %}
+          <a href="{{pattern.add_a_pattern_link}}" >
+            <div class="b-tools__pattern-button scale-on-hover">
+              <img src="{{ "/images/ic-add.svg" | relative_url }}">
+              <div>Add a pattern</div>
+            </div>
+          </a>
+        {% endif %}
+      </div>
       <div class="b-tools__shadow b-tools__mobile"></div>
     </div>
   </div>

--- a/privacy_toolkit.md
+++ b/privacy_toolkit.md
@@ -28,6 +28,8 @@ patterns:
         link: #
       - title: Traffic Light
         link: #
+    add_a_pattern_link: https://forms.gle/81UvA3gT63kJmr3V8
+
 
   - title: Discovering and learning about the study
     header_color: 3DD6C8
@@ -42,6 +44,8 @@ patterns:
         link: #
       - title: Data Sharing Options
         link: #
+    add_a_pattern_link: https://forms.gle/81UvA3gT63kJmr3V8
+
 
   - title: Using the research app
     header_color: 7692D9
@@ -52,6 +56,7 @@ patterns:
         link: /just-in-time-permission.html
       - title: Minimization of Data Collection
         link: #
+    add_a_pattern_link: https://forms.gle/81UvA3gT63kJmr3V8
 
   - title: Making sense of one's contribution and return of data/results
     header_color: 7EC8CC
@@ -66,7 +71,8 @@ patterns:
         link: #
       - title: Private Share Link
         link: #
-
+    add_a_pattern_link: https://forms.gle/81UvA3gT63kJmr3V8
+    
   - title: Leaving the study
     header_color: F47E6C
     image: leaving-the-study.svg
@@ -76,6 +82,8 @@ patterns:
         link: #
       - title: Data Access
         link: #
+    add_a_pattern_link: https://forms.gle/81UvA3gT63kJmr3V8
+            
 ---
 
 The content goes here....


### PR DESCRIPTION
If you don't provide `add_a_pattern_link`, the "Add a pattern" button gets hidden